### PR TITLE
domd/weston: Fix weston.ini creation

### DIFF
--- a/recipes-domd/agl/files/meta-xt-prod-extra/recipes-graphics/wayland/weston-ini-conf.bbappend
+++ b/recipes-domd/agl/files/meta-xt-prod-extra/recipes-graphics/wayland/weston-ini-conf.bbappend
@@ -7,21 +7,21 @@ SRC_URI_remove = "file://kingfisher_output.cfg"
 # Salvator-X M3
 SRC_URI_remove = "file://hdmi-a-1-270.cfg"
 
-SRC_URI_salvator-xs-h3-xt += "\
+SRC_URI_append_salvator-xs-h3-xt += "\
     file://hdmi-a-1-on-270.cfg \
     file://hdmi-2-on.cfg \
     file://vga-1-off.cfg \
     file://lvds-1-off.cfg \
 "
 
-SRC_URI_salvator-x-h3-4x2g-xt += "\
+SRC_URI_append_salvator-x-h3-4x2g-xt += "\
     file://hdmi-a-1-on-270.cfg \
     file://hdmi-2-on.cfg \
     file://vga-1-off.cfg \
     file://lvds-1-off.cfg \
 "
 
-SRC_URI_salvator-x-m3-xt += "\
+SRC_URI_append_salvator-x-m3-xt += "\
     file://hdmi-a-1-on.cfg \
     file://vga-1-on.cfg \
     file://lvds-1-off.cfg \


### PR DESCRIPTION
Do not override SRC_URI while creating weston.ini configuration
file, but instead append CES2019 specific configuration
segments.

Signed-off-by: Oleksandr Andrushchenko <andr2000@gmail.com>