### PR TITLE
domd/agl: Rebase connman patch...

### DIFF
--- a/recipes-domd/agl/files/meta-xt-prod-extra/recipes-connectivity/connman/connman_%.bbappend
+++ b/recipes-domd/agl/files/meta-xt-prod-extra/recipes-connectivity/connman/connman_%.bbappend
@@ -3,11 +3,13 @@ FILESEXTRAPATHS_prepend := "${THISDIR}/files:"
 SRC_URI += " \
     file://main.conf \
     file://disable_dns_proxy.conf \
+    file://0001-disable-when-booting-over-nfs-rebased.patch \
 "
 
 # Do not stop systemd-resolved service when we use connman as network manager.
 SRC_URI_remove = " \
     file://0001-connman.service-stop-systemd-resolved-when-we-use-co.patch \
+    file://0001-disable-when-booting-over-nfs.patch \
 "
 
 FILES_${PN} += " \

--- a/recipes-domd/agl/files/meta-xt-prod-extra/recipes-connectivity/connman/files/0001-disable-when-booting-over-nfs-rebased.patch
+++ b/recipes-domd/agl/files/meta-xt-prod-extra/recipes-connectivity/connman/files/0001-disable-when-booting-over-nfs-rebased.patch
@@ -1,0 +1,10 @@
+--- a/src/connman.service.in	2016-08-15 13:51:03.479478140 +0200
++++ b/src/connman.service.in	2016-08-15 13:51:33.469478267 +0200
+@@ -7,6 +7,7 @@ RequiresMountsFor=@localstatedir@/lib/co
+ After=dbus.service network-pre.target systemd-sysusers.service
+ Before=network.target multi-user.target shutdown.target
+ Wants=network.target
++ConditionKernelCommandLine=!root=/dev/nfs
+ 
+ [Service]
+ Type=dbus


### PR DESCRIPTION
0001-disable-when-booting-over-nfs.patch which now cannot be
applied because it needs rebase.

Fixes: fd0c16abc8ea ("domd/agl: Do not stop systemd-resolved service when...")

Signed-off-by: Oleksandr Andrushchenko <oleksandr_andrushchenko@epam.com>