### PR TITLE
Update visconfig: use embedded plugins

### DIFF
--- a/recipes-domd/agl/files/meta-xt-prod-extra/recipes-aos/aos-vis/files/visconfig.json
+++ b/recipes-domd/agl/files/meta-xt-prod-extra/recipes-aos/aos-vis/files/visconfig.json
@@ -4,12 +4,12 @@
 	"VISKey": "/var/aos/vis/data/wwwivi.key.pem",
 	"Adapters": [
 		{
-			"Plugin": "/usr/lib/aos/plugins/telemetryemulatoradapter.so",
+			"Plugin": "telemetryemulatoradapter",
 			"Params": {
 				"SensorURL": "http://localhost:8800"
 			}
 		},{
-			"Plugin": "/usr/lib/aos/plugins/storageadapter.so",
+			"Plugin": "storageadapter",
 			"Params": {
 				"Data" : {
 					"Attribute.Vehicle.VehicleIdentification.VIN": {"Value": "VIN", "Public": true, "ReadOnly": true},


### PR DESCRIPTION
As currently we can't build go plugins, vis-config use embedded storage and
telemetryemulator adapters. Update VIS config to use embedded adapters.

Signed-off-by: Oleksandr Grytsov <oleksandr_grytsov@epam.com>