### PR TITLE
domd/agl: USe own ALSA configuration

### DIFF
--- a/recipes-domd/agl/files/meta-agl-bsp/conf/include/agl_rcar_xt.inc
+++ b/recipes-domd/agl/files/meta-agl-bsp/conf/include/agl_rcar_xt.inc
@@ -60,4 +60,8 @@ BBMASK .= "|kernel-module-uvcs-drv|omx-user-module|gstreamer1.0-omx"
 # Provide own pulseaudio configuration
 BBMASK .= "|meta-audio-4a-framework/recipes-multimedia/pulseaudio/pulseaudio_%.bbappend"
 
+# Provide own ALSA configuration
+BBMASK .= "|meta-rcar-gen3/recipes-bsp/alsa-state/alsa-state.bbappend"
+
+
 OSTREE_BOOTLOADER ?= "u-boot"


### PR DESCRIPTION
Do not use configuration provided by AGL, but use ours.

Signed-off-by: Oleksandr Andrushchenko <oleksandr_andrushchenko@epam.com>
Signed-off-by: Ruslan Shymkevych <ruslan_shymkevych@epam.com>