### PR TITLE
domd: add more wildcards to weston seats

### DIFF
--- a/recipes-domd/agl/files/meta-xt-prod-extra/recipes-graphics/wayland/weston/weston-seats.rules
+++ b/recipes-domd/agl/files/meta-xt-prod-extra/recipes-graphics/wayland/weston/weston-seats.rules
@@ -1,2 +1,2 @@
-DEVPATH=="/devices/platform/soc/ee0a0100.usb/usb*/*", ENV{WL_OUTPUT}="HDMI-A-1"
-DEVPATH=="/devices/platform/soc/ee0c0100.usb/usb*/*", ENV{WL_OUTPUT}="HDMI-A-2"
+DEVPATH=="/devices/platform/soc/ee0a*.usb/usb*/*", ENV{WL_OUTPUT}="HDMI-A-1"
+DEVPATH=="/devices/platform/soc/ee0c*.usb/usb*/*", ENV{WL_OUTPUT}="HDMI-A-2"


### PR DESCRIPTION
Added more wildcards to USB device pathes to
support more variate hardware(like ILITEK ILITEK-TP).

Signed-off-by: Andrii Chepurnyi <andrii_chepurnyi@epam.com>