### PR TITLE
domd: Enable Weston V4L2 renderer

### DIFF
--- a/recipes-domd/agl/files/meta-agl-bsp/conf/include/agl_rcar_xt.inc
+++ b/recipes-domd/agl/files/meta-agl-bsp/conf/include/agl_rcar_xt.inc
@@ -34,7 +34,11 @@ PREFERRED_VERSION_gstreamer1.0-plugins-good = "1.12.2"
 PREFERRED_VERSION_gstreamer1.0-plugins-ugly = "1.12.2"
 PREFERRED_VERSION_gstreamer1.0-plugins-vspfilter = "1.0%"
 
-#MACHINE_FEATURES_append = " multimedia"
+# Enable Multimedia features
+MACHINE_FEATURES_append = " multimedia"
+
+# for weston v4l2 renderer
+DISTRO_FEATURES_append = " v4l2-renderer"
 
 #DISTRO_FEATURES_append = " use_eva_pkg"
 


### PR DESCRIPTION
Enable Weston V4L2 renderer, which runs using VSPM device.
This change:
1. Enables vsp2/vspm kernel modules
2. Appends "--use-v4l2" argument to weston-launch/weston
3. Makes weston use v4l2 renderer

This is a port of [ commit 0a7e56cad69300afb97862d1c8cb270230bc4afd ]
from meta-xt-prod-devel.

Signed-off-by: Oleksandr Andrushchenko <oleksandr_andrushchenko@epam.com>