### PR TITLE
All domains must use manifests without open coding...

### DIFF
--- a/recipes-domd/agl/files/meta-agl-bsp/conf/include/agl_rcar_xt.inc
+++ b/recipes-domd/agl/files/meta-agl-bsp/conf/include/agl_rcar_xt.inc
@@ -63,5 +63,5 @@ BBMASK .= "|meta-audio-4a-framework/recipes-multimedia/pulseaudio/pulseaudio_%.b
 # Provide own ALSA configuration
 BBMASK .= "|meta-rcar-gen3/recipes-bsp/alsa-state/alsa-state.bbappend"
 
-
+BB_DANGLINGAPPENDS_WARNONLY = "yes"
 OSTREE_BOOTLOADER ?= "u-boot"

--- a/recipes-domd/agl/files/meta-xt-prod-extra/recipes-platform/images/agl-demo-platform.bbappend
+++ b/recipes-domd/agl/files/meta-xt-prod-extra/recipes-platform/images/agl-demo-platform.bbappend
@@ -1,3 +1,8 @@
 require inc/agl-image.inc
 
 inherit populate_sdk_qt5
+
+IMAGE_INSTALL_remove = " \
+    aos-vis \
+    telemetry-emulator \
+"

--- a/recipes-domd/agl/inc/domd-agl-image.inc
+++ b/recipes-domd/agl/inc/domd-agl-image.inc
@@ -16,8 +16,6 @@ XT_QUIRK_UNPACK_SRC_URI += "file://meta-agl;subdir=repo"
 XT_QUIRK_UNPACK_SRC_URI += "file://meta-agl-bsp;subdir=repo/meta-agl"
 
 # these layers will be added to bblayers.conf on do_configure
-XT_QUIRK_BB_ADD_LAYER += "meta-golang"
-XT_QUIRK_BB_ADD_LAYER += "meta-aos"
 XT_QUIRK_BB_ADD_LAYER += "meta-xt-prod-extra"
 
 # Override revision of AGL auxiliary layers
@@ -44,10 +42,7 @@ SRCREV_agl-repo = "${AUTOREV}"
 SRCREV_img-proprietary = "${AUTOREV}"
 SRCREV_metago = "${AUTOREV}"
 
-SRC_URI_rcar = "repo://gerrit.automotivelinux.org/gerrit/AGL/AGL-repo;protocol=https;branch=flounder;manifest=flounder_6.0.2.xml;scmdata=keep;name=agl-repo \
-    git://git@gitpct.epam.com/epmd-aepr/img-proprietary;protocol=ssh;branch=master;name=img-proprietary;destsuffix=repo/proprietary \
-    git://github.com/madisongh/meta-golang.git;protocol=https;destsuffix=repo/meta-golang;branch=rocko;name=metago \
-    git://git@gitpct.epam.com/epmd-aepr/meta-aos.git;protocol=ssh;branch=master;destsuffix=repo/meta-aos \
+SRC_URI_rcar = " \
     file://0001-Do-not-try-to-use-XDG-environment-while-setting-up.patch \
 "
 GLES_VERSION_rcar = "1.9"

--- a/recipes-domd/domd-agl-demo-platform/domd-agl-demo-platform.bbappend
+++ b/recipes-domd/domd-agl-demo-platform/domd-agl-demo-platform.bbappend
@@ -1,2 +1,5 @@
 require ../agl/inc/domd-agl-image.inc
 
+SRC_URI_rcar_append = " \
+    repo://github.com/xen-troops/manifests;protocol=https;branch=master;manifest=prod_ces2019/domd.xml;scmdata=keep \
+"

--- a/recipes-domu/domu-image-android/domu-image-android.bbappend
+++ b/recipes-domu/domu-image-android/domu-image-android.bbappend
@@ -4,6 +4,10 @@ FILESEXTRAPATHS_prepend := "${THISDIR}/../../inc:"
 # we need MACHINEOVERRIDES from DomD build
 do_configure[depends] += "domd-agl-demo-platform:do_domd_install_machine_overrides"
 
+SRC_URI = " \
+    repo://github.com/xen-troops/manifests;protocol=https;branch=master;manifest=prod_devel/domu_android_host_tools.xml;scmdata=keep \
+"
+
 XT_BB_LAYERS_FILE = "meta-xt-prod-extra/doc/bblayers.conf.domu-image-android"
 XT_BB_LOCAL_CONF_FILE = "meta-xt-prod-extra/doc/local.conf.domu-image-android"
 
@@ -13,8 +17,8 @@ XT_BB_LOCAL_CONF_FILE = "meta-xt-prod-extra/doc/local.conf.domu-image-android"
 # these will be populated into the inner build system on do_unpack_xt_extras
 # N.B. xt_shared_env.inc MUST be listed AFTER meta-xt-prod-extra
 XT_QUIRK_UNPACK_SRC_URI += "\
-    file://meta-xt-prod-extra \
-    file://xt_shared_env.inc;subdir=meta-xt-prod-extra/inc \
+    file://meta-xt-prod-extra;subdir=repo \
+    file://xt_shared_env.inc;subdir=repo/meta-xt-prod-extra/inc \
 "
 
 # these layers will be added to bblayers.conf on do_configure

--- a/recipes-domu/domu-image-fusion/domu-image-fusion.bbappend
+++ b/recipes-domu/domu-image-fusion/domu-image-fusion.bbappend
@@ -12,7 +12,6 @@ XT_QUIRK_UNPACK_SRC_URI += " \
 "
 
 XT_QUIRK_BB_ADD_LAYER_append = " \
-    meta-golang \
     meta-xt-prod-extra \
 "
 ################################################################################
@@ -21,12 +20,6 @@ XT_QUIRK_BB_ADD_LAYER_append = " \
 SRC_URI += " \
     repo://github.com/xen-troops/manifests;protocol=https;branch=master;manifest=prod_devel/domf.xml;scmdata=keep \
 "
-
-SRC_URI += " \
-    git://github.com/madisongh/meta-golang.git;protocol=https;destsuffix=repo/meta-golang;branch=rocko;name=metago \
-"
-
-SRCREV_metago = "${AUTOREV}"
 
 XT_BB_LAYERS_FILE = "meta-xt-prod-extra/doc/bblayers.conf.domf-image-minimal"
 XT_BB_LOCAL_CONF_FILE = "meta-xt-prod-extra/doc/local.conf.domf-image-minimal"

--- a/recipes-domu/domu-image-fusion/files/meta-xt-prod-extra/doc/bblayers.conf.domf-image-minimal
+++ b/recipes-domu/domu-image-fusion/files/meta-xt-prod-extra/doc/bblayers.conf.domf-image-minimal
@@ -13,6 +13,7 @@ BBLAYERS ?= " \
   ${TOPDIR}/../meta-openembedded/meta-python \
   ${TOPDIR}/../meta-openembedded/meta-networking \
   ${TOPDIR}/../meta-openembedded/meta-filesystems \
+  ${TOPDIR}/../meta-golang \
 "
 
 BBLAYERS_NON_REMOVABLE ?= " \

--- a/recipes-domu/domu-image-litmusrt/domu-image-litmusrt.bbappend
+++ b/recipes-domu/domu-image-litmusrt/domu-image-litmusrt.bbappend
@@ -3,12 +3,8 @@ XT_QUIRK_BB_ADD_LAYER += " \
     meta-litmusrt \
 "
 
-# Set default poky revision to pyro
-BRANCH = "pyro"
-
 SRC_URI = " \
-    git://git.yoctoproject.org/poky;destsuffix=repo/poky;branch=${BRANCH} \
-    git://github.com/xen-troops/meta-litmusrt.git;destsuffix=repo/meta-litmusrt;branch=master \
+    repo://github.com/xen-troops/manifests;protocol=https;branch=master;manifest=prod_devel/domr.xml;scmdata=keep \
 "
 
 SRCREV = "${AUTOREV}"

--- a/recipes-domu/domu-image-weston/domu-image-weston.bbappend
+++ b/recipes-domu/domu-image-weston/domu-image-weston.bbappend
@@ -8,10 +8,6 @@ SRC_URI = " \
     repo://github.com/xen-troops/manifests;protocol=https;branch=master;manifest=prod_devel/domu.xml;scmdata=keep \
 "
 
-SRC_URI_append = " \
-    git://github.com/kraj/meta-clang.git;destsuffix=repo/meta-clang;branch=rocko \
-"
-
 XT_QUIRK_UNPACK_SRC_URI += " \
     file://meta-xt-prod-extra;subdir=repo \
     file://xt_shared_env.inc;subdir=repo/meta-xt-prod-extra/inc \
@@ -19,7 +15,6 @@ XT_QUIRK_UNPACK_SRC_URI += " \
 
 XT_QUIRK_BB_ADD_LAYER += " \
     meta-xt-prod-extra \
-    meta-clang \
 "
 
 XT_BB_IMAGE_TARGET = "core-image-weston"

--- a/recipes-domu/domu-image-weston/files/meta-xt-prod-extra/doc/bblayers.conf.rcar-domu-image-weston
+++ b/recipes-domu/domu-image-weston/files/meta-xt-prod-extra/doc/bblayers.conf.rcar-domu-image-weston
@@ -14,6 +14,7 @@ BBLAYERS ?= " \
   ${TOPDIR}/../meta-openembedded/meta-oe \
   ${TOPDIR}/../meta-openembedded/meta-networking \
   ${TOPDIR}/../meta-openembedded/meta-python \
+  ${TOPDIR}/../meta-clang \
   "
 BBLAYERS_NON_REMOVABLE ?= " \
   ${TOPDIR}/../poky/meta \


### PR DESCRIPTION
additional meta layers in SRC_URI. There are domain recipes
which either do not use manifest files to retrieve the meta
layers used during the build or manually adding meta layers
to existing manifests. All these prevents build reconstruction
to run correctly, so fix these issues.

Signed-off-by: Oleksandr Andrushchenko <oleksandr_andrushchenko@epam.com>
Signed-off-by: Iurii Artemenko <iurii_artemenko@epam.com>
Reviewed-by: Oleksandr Andrushchenko <oleksandr_andrushchenko@epam.com>