### PR TITLE
Fix build with multimedia feature turned-on

### DIFF
--- a/recipes-domd/agl/files/meta-xt-prod-extra/recipes-platform/packagegroups/packagegroup-agl-core-multimedia.bbappend
+++ b/recipes-domd/agl/files/meta-xt-prod-extra/recipes-platform/packagegroups/packagegroup-agl-core-multimedia.bbappend
@@ -1,0 +1,4 @@
+RDEPENDS_${PN}_remove += " \
+        packagegroup-multimedia-kernel-modules \
+        packagegroup-gstreamer1.0-plugins \
+"


### PR DESCRIPTION
Weston V4L2 renderer requires multimedia feature turned-on
which leeds as to unneeded dependencies such as gstreamer
plugins ets. So, remove unused package groups.

Signed-off-by: Iurii Artemenko <iurii_artemenko@epam.com>