### PR TITLE
Bring back removed apps

### DIFF
--- a/recipes-domd/agl/files/meta-xt-prod-extra/recipes-platform/images/agl-demo-platform.bbappend
+++ b/recipes-domd/agl/files/meta-xt-prod-extra/recipes-platform/images/agl-demo-platform.bbappend
@@ -1,8 +1,3 @@
 require inc/agl-image.inc
 
 inherit populate_sdk_qt5
-
-IMAGE_INSTALL_remove = " \
-    aos-vis \
-    telemetry-emulator \
-"


### PR DESCRIPTION
An aos-vis and telemetry-emulator applications were removed
due to meta-aos layer absence so, bring them back.

Signed-off-by: Iurii Artemenko <iurii_artemenko@epam.com>