### PR TITLE
dom0:domd:xen: Unify XEN version for Dom0 and DomD

### DIFF
--- a/inc/xen-version.inc
+++ b/inc/xen-version.inc
@@ -1,0 +1,8 @@
+
+################################################################################
+# Following inc file defines XEN version and needed glue info to get it
+# built with the current yocto version
+################################################################################
+require ../meta-xt-images-domx/recipes-extended/xen/xen-4.10-rocko.inc
+
+SRC_URI = "git://github.com/xen-troops/xen.git;protocol=https;branch=master"

--- a/recipes-dom0/dom0-image-thin-initramfs/dom0-image-thin-initramfs.bbappend
+++ b/recipes-dom0/dom0-image-thin-initramfs/dom0-image-thin-initramfs.bbappend
@@ -32,6 +32,7 @@ SRC_URI = "repo://github.com/xen-troops/manifests;protocol=https;branch=master;m
 XT_QUIRK_UNPACK_SRC_URI += "\
     file://meta-xt-prod-extra;subdir=repo \
     file://xt_shared_env.inc;subdir=repo/meta-xt-prod-extra/inc \
+    file://xen-version.inc;subdir=repo/meta-xt-prod-extra/recipes-extended/xen \
 "
 
 # these layers will be added to bblayers.conf on do_configure

--- a/recipes-dom0/dom0-image-thin-initramfs/files/meta-xt-prod-extra/recipes-extended/xen/xen_git.bbappend
+++ b/recipes-dom0/dom0-image-thin-initramfs/files/meta-xt-prod-extra/recipes-extended/xen/xen_git.bbappend
@@ -1,14 +1,14 @@
 FILESEXTRAPATHS_prepend := "${THISDIR}/files:"
 
 ################################################################################
+# Following inc file defines XEN version for the product and its SRC_URI
+################################################################################
+require xen-version.inc
+
+################################################################################
 # We only need Xen tools, so we can start domains
 ################################################################################
-XEN_REL = "4.10"
-PV = "${XEN_REL}.0+git${SRCPV}"
-SRCREV = "${AUTOREV}"
-
-SRC_URI = " \
-    git://github.com/xen-troops/xen.git;protocol=https;branch=master \
+SRC_URI_append = " \
     file://0001-libxl-Add-DTB-compatible-list-to-config-file.patch \
     file://0002-libxl-Add-DTB-passthrough-nodes-list.patch \
 "

--- a/recipes-domd/agl/files/meta-xt-prod-extra/recipes-extended/xen/xen_git.bbappend
+++ b/recipes-domd/agl/files/meta-xt-prod-extra/recipes-extended/xen/xen_git.bbappend
@@ -1,15 +1,13 @@
 FILESEXTRAPATHS_prepend := "${THISDIR}/files:"
 
 ################################################################################
+# Following inc file defines XEN version for the product and its SRC_URI
+################################################################################
+require xen-version.inc
+
+################################################################################
 # Renesas R-Car
 ################################################################################
-
-XEN_REL_rcar = "4.10"
-PV = "${XEN_REL}.0+git${SRCPV}"
-SRCREV_rcar = "${AUTOREV}"
-
-SRC_URI_rcar = "git://github.com/xen-troops/xen.git;protocol=https;branch=master"
-
 # N.B. as Xen doesn't support partial .cfg as kernel does
 # we need to patch it to select disable IPMMU PGT sharing for
 # H3 v2.0 and M3 machines

--- a/recipes-domd/agl/inc/domd-agl-image.inc
+++ b/recipes-domd/agl/inc/domd-agl-image.inc
@@ -9,6 +9,7 @@ FILESEXTRAPATHS_prepend := "${THISDIR}/../../../inc:"
 XT_QUIRK_UNPACK_SRC_URI += "\
     file://meta-xt-prod-extra;subdir=repo \
     file://xt_shared_env.inc;subdir=repo/meta-xt-prod-extra/inc \
+    file://xen-version.inc;subdir=repo/meta-xt-prod-extra/recipes-extended/xen \
 "
 
 # add new xt-distro machines into AGL


### PR DESCRIPTION
Unify XEN version for Dom0 and DomD in one include file and use an
appropriate glue file for the yocto version.

This is a port of [ commit 31c4ce118527aa0cf8eff0fbf39d4067e7950fe5 ]
from meta-xt-prod-devel.

Signed-off-by: Andrii Anisov <andrii_anisov@epam.com>