### PR TITLE
Set fixed revision for Xen

### DIFF
--- a/inc/xen-version.inc
+++ b/inc/xen-version.inc
@@ -5,4 +5,5 @@
 ################################################################################
 require ../meta-xt-images-domx/recipes-extended/xen/xen-4.10-rocko.inc
 
-SRC_URI = "git://github.com/xen-troops/xen.git;protocol=https;branch=master"
+SRC_URI = "git://github.com/xen-troops/xen.git;protocol=https"
+SRCREV = "RELEASE-4.10.0-xt0.6.final"


### PR DESCRIPTION
In order of migration to Xen-v4.12 set fixed revision
of Xen-v4.10.

Signed-off-by: Iurii Artemenko <iurii_artemenko@epam.com>